### PR TITLE
Test for shutil.which directly

### DIFF
--- a/whichcraft.py
+++ b/whichcraft.py
@@ -5,6 +5,7 @@ __email__ = 'pydanny@gmail.com'
 __version__ = '0.4.0'
 
 import os
+import sys
 
 try:
     from shutil import which

--- a/whichcraft.py
+++ b/whichcraft.py
@@ -2,20 +2,14 @@
 
 __author__ = 'Daniel Roy Greenfeld'
 __email__ = 'pydanny@gmail.com'
-__version__ = '0.3.1'
-
+__version__ = '0.4.0'
 
 import os
-import sys
 
-PY3 = sys.version_info[0] == 3
-
-
-if PY3:  # Forced testing
-
+try:
     from shutil import which
-
-else:  # Forced testing
+except ImportError:
+    # Versions prior to Python 3.3 don't have shutil.which
 
     def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         """Given a command, mode, and a PATH string, return the path which


### PR DESCRIPTION
Rather than checking for Python 3, this change checks the shutil
module directly for a which attribute, and falls back to the
backported implementation if it doesn't find one.
