### PR TITLE
Fix for failing builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
 	py.test --cov=whichcraft --cov-report html
-	open htmlcov/index.html
+	open htmlcov/index.html | xdg-open htmlcov/index.html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest
 wheel>=0.23.0
-pytest-cov>=2.1.0
+pytest-cov<=2.6.0


### PR DESCRIPTION
Some tests were failing possibly because of this bug: https://github.com/pywbem/pywbem/issues/1371

This PR is a workaround that pins `pytest_cov` to version 2.6.0